### PR TITLE
Fix #2  & #3

### DIFF
--- a/lib/pages/material_page.dart
+++ b/lib/pages/material_page.dart
@@ -34,96 +34,107 @@ class _MyMaterialPageState extends State<MyMaterialPage> {
     return Scaffold(
       backgroundColor: invertColorsMaterial(context), //color changes
       // according to currently set theme
-      body: Container(
-        child: Stack(
-          children: <Widget>[
-            Column(
-              children: <Widget>[
-                Padding(
-                  padding: EdgeInsets.only(
-                    left: 10.0,
-                    top: 50.0,
-                  ),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    children: <Widget>[
-                      IconButton(
-                        icon: Icon(EvaIcons.arrowIosBack),
-                        tooltip: 'Go back',
-                        color: invertColorsMild(context),
-                        iconSize: 26.0,
-                        onPressed: () {
-                          Navigator.pop(context);
-                        },
-                      ),
-                      Text(
-                        'Material++',
-                        style: TextStyle(
-                            fontFamily: 'Rubik',
-                            fontWeight: FontWeight.w600,
-                            fontSize: 22.0,
-                            fontStyle: FontStyle.italic,
-                            color: invertColorsMild(context)),
-                      ),
-                    ],
-                  ),
-                ),
-                Expanded(
-                  child: GridView.count(
-                    crossAxisCount: 1,
-                    childAspectRatio: 1,
-                    children: List.generate(
-                      1,
-                      (index) {
-                        return Hero(
-                          tag: 'tile0',
-                          child: buildTile(
-                            context,
-                            tileColors[0],
-                            splashColors[0],
-                            Column(
-                                mainAxisAlignment: MainAxisAlignment.center,
-                                crossAxisAlignment: CrossAxisAlignment.center,
-                                children: <Widget>[
-                                  Text(
-                                    '${itemNames[0]}',
-                                    style: TextStyle(
-                                        fontWeight: FontWeight.w700,
-                                        fontSize: 20.0,
-                                        color: invertColorsMild(context)),
-                                    softWrap: true,
-                                    overflow: TextOverflow.fade,
-                                    maxLines: 1,
-                                  ),
-                                  SizedBox(
-                                    height: 5.0,
-                                  ),
-                                  Text(
-                                    '${itemNames[1]}',
-                                    style: TextStyle(
-                                        fontWeight: FontWeight.w700,
-                                        fontSize: 20.0,
-                                        color: invertColorsMild(context)),
-                                    softWrap: true,
-                                    overflow: TextOverflow.fade,
-                                    maxLines: 1,
-                                  ),
-                                ]),
-                            onTap: () {
-                              doNothing();
-                            },
-                          ),
-                        );
-                      },
+      body: WillPopScope(
+        onWillPop: this.handleBackPressed,
+        child: Container(
+          child: Stack(
+            children: <Widget>[
+              Column(
+                children: <Widget>[
+                  Padding(
+                    padding: EdgeInsets.only(
+                      left: 10.0,
+                      top: 50.0,
+                    ),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      children: <Widget>[
+                        IconButton(
+                          icon: Icon(EvaIcons.arrowIosBack),
+                          tooltip: 'Go back',
+                          color: invertColorsMild(context),
+                          iconSize: 26.0,
+                          onPressed: () {
+                            Navigator.pop(context);
+                          },
+                        ),
+                        Text(
+                          'Material++',
+                          style: TextStyle(
+                              fontFamily: 'Rubik',
+                              fontWeight: FontWeight.w600,
+                              fontSize: 22.0,
+                              fontStyle: FontStyle.italic,
+                              color: invertColorsMild(context)),
+                        ),
+                      ],
                     ),
                   ),
-                ),
-              ],
-            ),
-            SexyBottomSheet(), //the awesome sliding up bottom sheet
-          ],
+                  Expanded(
+                    child: GridView.count(
+                      crossAxisCount: 1,
+                      childAspectRatio: 1,
+                      children: List.generate(
+                        1,
+                        (index) {
+                          return Hero(
+                            tag: 'tile0',
+                            child: buildTile(
+                              context,
+                              tileColors[0],
+                              splashColors[0],
+                              Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  crossAxisAlignment: CrossAxisAlignment.center,
+                                  children: <Widget>[
+                                    Text(
+                                      '${itemNames[0]}',
+                                      style: TextStyle(
+                                          fontWeight: FontWeight.w700,
+                                          fontSize: 20.0,
+                                          color: invertColorsMild(context)),
+                                      softWrap: true,
+                                      overflow: TextOverflow.fade,
+                                      maxLines: 1,
+                                    ),
+                                    SizedBox(
+                                      height: 5.0,
+                                    ),
+                                    Text(
+                                      '${itemNames[1]}',
+                                      style: TextStyle(
+                                          fontWeight: FontWeight.w700,
+                                          fontSize: 20.0,
+                                          color: invertColorsMild(context)),
+                                      softWrap: true,
+                                      overflow: TextOverflow.fade,
+                                      maxLines: 1,
+                                    ),
+                                  ]),
+                              onTap: () {
+                                doNothing();
+                              },
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              SexyBottomSheet(), //the awesome sliding up bottom sheet
+            ],
+          ),
         ),
       ),
     );
+  }
+
+  Future<bool> handleBackPressed() {
+    if (isBottomSheetOpen) {
+      toggleBottomSheet();
+      return Future.value(false);
+    }
+    return Future.value(true);
   }
 }

--- a/lib/widgets/bottom_sheet.dart
+++ b/lib/widgets/bottom_sheet.dart
@@ -18,10 +18,9 @@ const double iconsVerticalSpacing = 0;
 const double iconsHorizontalSpacing = 0;
 AnimationController controller;
 
-void toggle() {
-  final bool isOpen = controller.status == AnimationStatus.completed;
-  controller.fling(velocity: isOpen ? -2 : 2);
-}
+void toggleBottomSheet() =>
+    controller.fling(velocity: isBottomSheetOpen ? -2 : 2);
+bool get isBottomSheetOpen => (controller.status == AnimationStatus.completed);
 
 class SexyBottomSheet extends StatefulWidget {
   @override
@@ -79,7 +78,7 @@ class _SexyBottomSheetState extends State<SexyBottomSheet>
           right: 0,
           bottom: 0,
           child: GestureDetector(
-            onTap: toggle,
+            onTap: toggleBottomSheet,
             onVerticalDragUpdate: handleDragUpdate,
             onVerticalDragEnd: handleDragEnd,
             child: Container(
@@ -270,7 +269,7 @@ class MenuButton extends StatelessWidget {
       right: 0,
       bottom: 30,
       child: GestureDetector(
-        onTap: toggle,
+        onTap: toggleBottomSheet,
         child: AnimatedIcon(
           icon: AnimatedIcons.menu_close,
           size: 24.0,

--- a/lib/widgets/tile.dart
+++ b/lib/widgets/tile.dart
@@ -15,6 +15,7 @@ Widget buildTile(
       borderRadius: BorderRadius.circular(15.0),
       shadowColor: shadowColor(context),
       child: InkWell(
+        borderRadius: BorderRadius.circular(15.0),
         onTap: onTap != null
             ? () => onTap()
             : () {


### PR DESCRIPTION
Fix #2 by matching the ```borderRadius``` property for ```InkWell``` with the same value for the ```Material``` parent widget.
I initially tried to replace everything in ```builtTile```  with a simple ```RaisedButton``` widget. Which should make the code less cluttered and the render somewhat faster. (one widget instead of 3 !!)
But it messed up the colors, white becomes grey, and black is rendered blue ! 😨
We might try using ```RaisedButton``` in the future if needed more performance 😅.

Fix #3. back button should now Close bottom sheet if open, else it will return to home screen.