### PR TITLE
fix(gradle-build): fixes an issue where the android build fails if there is no keystore file

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -27,8 +27,10 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 def keystoreProperties = new Properties()
 def keystorePropertiesFile = rootProject.file('key.properties')
+def hasKeystore = false
 if (keystorePropertiesFile.exists()) {
-   keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+    hasKeystore = true
 }
 
 android {
@@ -51,23 +53,32 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
-   signingConfigs {
-       release {
-           keyAlias keystoreProperties['keyAlias']
-           keyPassword keystoreProperties['keyPassword']
-           storeFile file(keystoreProperties['storeFile'])
-           storePassword keystoreProperties['storePassword']
-       }
-   }
+    if (hasKeystore == true) {
+        signingConfigs {
+            release {
+                keyAlias keystoreProperties['keyAlias']
+                keyPassword keystoreProperties['keyPassword']
+                storeFile file(keystoreProperties['storeFile'])
+                storePassword keystoreProperties['storePassword']
+            }
+        }
 
-   buildTypes {
-       release {
-           signingConfig signingConfigs.release
-           minifyEnabled false
-           useProguard false
-           proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-       }
-   }
+        buildTypes {
+            release {
+                signingConfig signingConfigs.release
+                minifyEnabled false
+                useProguard false
+                proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            }
+        }
+    }
+    else {
+        buildTypes {
+            release {
+                signingConfig signingConfigs.debug
+            }
+        }
+    }
 }
 
 flutter {


### PR DESCRIPTION
I noticed the build was failing when trying to run this project in release mode for android as advised in the readme. I also noticed you had this same problem yourself (#7) and it was resolved when you restored your keystore file. 

I added a conditional statement that allows someone that's just cloned the project to be able to run it in release mode (using the default `signingConfigs.debug`) while still allowing you to use your signed version.

Love the project by the way! Haven't had much of a chance to play with it yet, but I'd love to offer any help I can.