### PR TITLE
added hero animations for page titles navigating from home_page, potential fix for #4

### DIFF
--- a/lib/pages/about_page.dart
+++ b/lib/pages/about_page.dart
@@ -56,14 +56,20 @@ class _MyAboutPageState extends State<MyAboutPage> {
                       Navigator.pop(context);
                     },
                   ),
-                  Text(
-                    'About',
-                    style: TextStyle(
-                      fontFamily: 'Rubik',
-                      fontWeight: FontWeight.w600,
-                      fontSize: 22.0,
-                      fontStyle: FontStyle.italic,
-                      color: invertColorsStrong(context),
+                  Hero(
+                    tag: 'title2',
+                    child: Material(
+                      color: Colors.transparent,
+                      child: Text(
+                        'About',
+                        style: TextStyle(
+                          fontFamily: 'Rubik',
+                          fontWeight: FontWeight.w600,
+                          fontSize: 22.0,
+                          fontStyle: FontStyle.italic,
+                          color: invertColorsStrong(context),
+                        ),
+                      ),
                     ),
                   ),
                 ],

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -59,47 +59,67 @@ class _MyHomePageState extends State<MyHomePage> {
                 children: List.generate(
                   itemNames.length,
                   (index) {
-                    return Hero(
-                      tag: 'tile$index', //using a different hero widget tag for
-                      // each page mapped to the page's index value
-                      child: SexyTile(
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          children: <Widget>[
-                            Text(
-                              '${itemNames[index]}',
-                              style: TextStyle(
-                                fontWeight: FontWeight.w700,
-                                fontSize: 22.0,
-                                color: invertColorsStrong(context),
-                              ),
-                              softWrap: true,
-                              overflow: TextOverflow.fade,
-                              maxLines: 1,
-                            ),
-                          ],
+                    return Stack(
+                      fit: StackFit.expand,
+                      children: <Widget>[
+                        Hero(
+                          tag: 'tile$index', //using a different hero widget tag for
+                          // each page mapped to the page's index value
+                          child: SexyTile(
+                          ),
                         ),
-                        splashColor: MyColors.accentColor,
-                        onTap: () {
-                          Navigator.push(
-                            context,
-                            CupertinoPageRoute(
-                              builder: (context) {
-                                if (index == 0) {
-                                  return MyMaterialPage();
-                                } else if (index == 1) {
-                                  return MyGradientsPage();
-                                } else if (index == 2) {
-                                  return MyAboutPage();
-                                } else {
-                                  return null;
-                                }
+                        Container(
+                          margin: EdgeInsets.all(15.0),
+                          child: Material(
+                            color: Colors.transparent,
+                            child: InkWell(
+                              child: Row(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                crossAxisAlignment: CrossAxisAlignment.center,
+                                children: <Widget>[
+                                  Hero(
+                                    tag: 'title${index}',
+                                    child: Material(
+                                      color: Colors.transparent,
+                                      child: Text(
+                                        '${itemNames[index]}',
+                                        style: TextStyle(
+                                          fontWeight: FontWeight.w700,
+                                          fontSize: 22.0,
+                                          color: invertColorsStrong(context),
+                                        ),
+                                        softWrap: true,
+                                        overflow: TextOverflow.fade,
+                                        maxLines: 1,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              splashColor: MyColors.accentColor,
+                              borderRadius: BorderRadius.circular(15.0),
+                              onTap: () {
+                                Navigator.push(
+                                  context,
+                                  CupertinoPageRoute(
+                                    builder: (context) {
+                                      if (index == 0) {
+                                        return MyMaterialPage();
+                                      } else if (index == 1) {
+                                        return MyGradientsPage();
+                                      } else if (index == 2) {
+                                        return MyAboutPage();
+                                      } else {
+                                        return null;
+                                      }
+                                    },
+                                  ),
+                                );
                               },
                             ),
-                          );
-                        }, //opens appropriate page,
-                      ),
+                          ),
+                        ),
+                      ],
                     );
                   },
                 ),

--- a/lib/pages/material_page.dart
+++ b/lib/pages/material_page.dart
@@ -48,14 +48,20 @@ class _MyMaterialPageState extends State<MyMaterialPage> {
                             Navigator.pop(context);
                           },
                         ),
-                        Text(
-                          'Material++',
-                          style: TextStyle(
-                            fontFamily: 'Rubik',
-                            fontWeight: FontWeight.w600,
-                            fontSize: 22.0,
-                            fontStyle: FontStyle.italic,
-                            color: invertColorsMild(context),
+                        Hero(
+                          tag: 'title0',
+                          child: Material(
+                            color: Colors.transparent,
+                            child: Text(
+                              'Material++',
+                              style: TextStyle(
+                                fontFamily: 'Rubik',
+                                fontWeight: FontWeight.w600,
+                                fontSize: 22.0,
+                                fontStyle: FontStyle.italic,
+                                color: invertColorsMild(context),
+                              ),
+                            ),
                           ),
                         ),
                       ],


### PR DESCRIPTION
I saw you initially tried to have the titles for the tiles as Hero animations, but because the text is a child of the tile, it wouldn't work. I separated the text from the tile and put them both in a stack, and put the text in an equal size container that's transparent so the InkWell and navigation could be applied.

My only problem with the way it is now is that the title flies through the tile when navigating back to the home page.

Let me know your thoughts and if you have any ideas or improvements.